### PR TITLE
SDCB-6084-APPSEC-42885 Json dependency vulnerability

### DIFF
--- a/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
+++ b/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
@@ -37,6 +37,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20180130</version>
+        </dependency>
+        <dependency>
             <groupId>com.testdroid</groupId>
             <artifactId>mobile-opencv-image-recognition-library</artifactId>
             <version>0.3</version>


### PR DESCRIPTION
The deprecated json-20151123 dependency was nested in another package:

![Screenshot 2022-08-18 at 16 07 12](https://user-images.githubusercontent.com/108719957/185415532-30a4ed25-d1a6-410f-a871-0d6c5a87d53d.png)

I added json-20180130 dependency (suggested by automat) to force newer version of package.
