### PR TITLE
SDCB-3378 Testing parallel security fix

### DIFF
--- a/samples/testng-parallel-mobile-tests/README.md
+++ b/samples/testng-parallel-mobile-tests/README.md
@@ -52,5 +52,5 @@
 
     Run test with your Bitbar api key:
     ```
-    mvn clean test -DBITBAR_API_KEY=<YOUR_BITBAR_API_KEY>
+    mvn clean test -DBITBAR_API_KEY=<YOUR_BITBAR_API_KEY> -Dtestng.dtd.http=true
     ```

--- a/samples/testng-parallel-mobile-tests/README.md
+++ b/samples/testng-parallel-mobile-tests/README.md
@@ -52,5 +52,5 @@
 
     Run test with your Bitbar api key:
     ```
-    mvn clean test -DBITBAR_API_KEY=<YOUR_BITBAR_API_KEY> -Dtestng.dtd.http=true
+    mvn clean test -DBITBAR_API_KEY=<YOUR_BITBAR_API_KEY>
     ```

--- a/samples/testng-parallel-mobile-tests/pom.xml
+++ b/samples/testng-parallel-mobile-tests/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0</version>
+            <version>7.3.0</version>
         </dependency>
 
         <dependency>

--- a/samples/testng-parallel-mobile-tests/src/test/java/SimpleGoogleTest.java
+++ b/samples/testng-parallel-mobile-tests/src/test/java/SimpleGoogleTest.java
@@ -1,7 +1,6 @@
 import base.BaseTest;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.WebElement;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/samples/testng-parallel-mobile-tests/src/test/resources/suites/TestSuite.xml
+++ b/samples/testng-parallel-mobile-tests/src/test/resources/suites/TestSuite.xml
@@ -1,4 +1,4 @@
-<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
 
 <suite name="Test Suite" thread-count="2" parallel="tests">
 


### PR DESCRIPTION
In my last PR when fixing testing parallel i missed one of security issues. Bumping one of dependencies versions fixes the problem but it requires adding additional flag to mvn test.