### PR TITLE
SDCB-6269-Cleanup-Robot-framework-sample

### DIFF
--- a/samples/testing-frameworks/robot-framework/README.md
+++ b/samples/testing-frameworks/robot-framework/README.md
@@ -6,7 +6,7 @@
 
 
 # How to install requirements:
-- pip install -r ./resources/requirements.txt
+- python3 -m pip install -r ./resources/requirements.txt
 
 # Running tests locally:
 There are two runner scripts for running the tests locally, ``run_android.py`` and ``run_ios.py``

--- a/samples/testing-frameworks/robot-framework/resources/requirements.txt
+++ b/samples/testing-frameworks/robot-framework/resources/requirements.txt
@@ -1,3 +1,4 @@
-robotframework>=3.0
-robotframework-appiumlibrary>=1.3.5
+Appium-Python-Client==0.45
+robotframework>=3.0.1
+robotframework-appiumlibrary>=1.4.4
 six>=1.11.0

--- a/samples/testing-frameworks/robot-framework/run-tests-android.sh
+++ b/samples/testing-frameworks/robot-framework/run-tests-android.sh
@@ -6,7 +6,7 @@ unzip -o tests.zip
 
 echo "Installing requirements"
 chmod 0755 resources/requirements.txt
-pip3 install -r resources/requirements.txt
+python3 -m pip install -r resources/requirements.txt
 
 ## start Appium server
 echo "Starting Appium ..."

--- a/samples/testing-frameworks/robot-framework/run-tests-ios.sh
+++ b/samples/testing-frameworks/robot-framework/run-tests-ios.sh
@@ -19,7 +19,7 @@ unzip -o tests.zip
 
 echo "Installing requirements"
 chmod 0755 resources/requirements.txt
-pip3 install --user  --requirement resources/requirements.txt
+python3 -m pip install --user  --requirement resources/requirements.txt
 
 ## Start test execution
 echo "Running test"


### PR DESCRIPTION
- Changed `pip` calls to `python3 -m pip` to make sure that requirements will be installed with the right pip.
- Fixed missing module bug: When running tests on bitbar _no module named selenium.webdriver.common.options_ error appeared. As far as I know that was caused by _robotframework-appiumlibrary_ module that was using a _Appium-Python-Client_ module which version probably didn't support Selenium 3. Forcing _Appium-Python-Client_  version (0.45) fixed it.
- Minor packages' versions bump