### PR TITLE
SDCB-6734-Testing-parallel-mobile-security-fix

### DIFF
--- a/samples/testng-parallel-mobile-tests/pom.xml
+++ b/samples/testng-parallel-mobile-tests/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.3.0</version>
+            <version>7.6.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Unfortunately previous security issues fix ([SDCB-3378](https://github.com/bitbar/test-samples/pull/452)) led to next issue this time due to another sub dependency. Although bumping testng version to 7.6.1 fixes the issue with org.apache.ant package it might still generate another problem because even the newest version of testng contains [vulnerability](https://mvnrepository.com/artifact/org.testng/testng/7.6.1).
We can either merge this PR and bump testng version hoping that it won't produce a new vulnerability or wait till next version's release.