### PR TITLE
xmlgraphics-commons vulnerability

### DIFF
--- a/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
+++ b/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
@@ -85,6 +85,11 @@
             <artifactId>maven-artifact</artifactId>
             <version>3.8.6</version>
         </dependency>
+      <dependency>
+        <groupId>org.apache.xmlgraphics</groupId>
+        <artifactId>xmlgraphics-commons</artifactId>
+        <version>2.6</version>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
+++ b/samples/testing-frameworks/appium/server-side/image-recognition/pom.xml
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>xmlgraphics-commons</artifactId>
-        <version>2.6</version>
+        <version>2.7</version>
       </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
Updated Apache XmlGraphics Commons dependency from version 1.4 to 2.6.