### PR TITLE
SDCB-8099-Fix-vulnerability-in-parallel-mobile-tests

### DIFF
--- a/samples/testng-parallel-mobile-tests/pom.xml
+++ b/samples/testng-parallel-mobile-tests/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.6.1</version>
+            <version>7.7.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Bumped `testng` version.