### PR TITLE
SDCB-9992 [Appium 2.0 Support] C# CS sample

### DIFF
--- a/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsAndroid.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsAndroid.cs
@@ -12,7 +12,7 @@ namespace BitbarBiometricSample
             capabilities.AddAdditionalCapability("platformName", "Android");
             capabilities.AddAdditionalCapability("appium:automationName", "uiautomator2");
             //Customizable
-            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, string>
             {
                 {"project", "C# Appium Automated Test"},
                 {"testrun", "Android Run" },

--- a/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsAndroid.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsAndroid.cs
@@ -10,14 +10,16 @@ namespace BitbarBiometricSample
         {
             //Platform dependent
             capabilities.AddAdditionalCapability("platformName", "Android");
-            capabilities.AddAdditionalCapability("deviceName", "Android Phone");
-            capabilities.AddAdditionalCapability("automationName", "Appium");
+            capabilities.AddAdditionalCapability("appium:automationName", "uiautomator2");
             //Customizable
-            capabilities.AddAdditionalCapability("bitbar_project", "C# Appium Automated Test");
-            capabilities.AddAdditionalCapability("bitbar_testrun", "Android Run");
-            capabilities.AddAdditionalCapability("bitbar_device", "Google Pixel 2");
-            //App ID
-            capabilities.AddAdditionalCapability("bitbar_app", "<APP_ID>");
+            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+            {
+                {"project", "C# Appium Automated Test"},
+                {"testrun", "Android Run" },
+                {"device", "Google Pixel 2"},
+                {"app", "<APP_ID>" }
+                //{"appiumVersion", "1.22.3"} //launch tests on appium 1
+            });
 
             driver = new AndroidDriver<AndroidElement>(new Uri(AppiumHubURL), capabilities, TimeSpan.FromSeconds(300));
         }

--- a/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsIOS.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsIOS.cs
@@ -14,7 +14,7 @@ namespace BitbarBiometricSample
             capabilities.AddAdditionalCapability("appium:automationName", "XCUITest");
             capabilities.AddAdditionalCapability("appium:deviceName", "iPhone device");
             //Customizable
-            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, string>
             {
                 {"project", "C# Appium Automated Test"},
                 {"testrun", "iOS Run"},

--- a/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsIOS.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/biometric-sample-test/BitbarBiometricSample/TestBiometricsIOS.cs
@@ -11,14 +11,17 @@ namespace BitbarBiometricSample
         {
             //Platform dependent
             capabilities.AddAdditionalCapability("platformName", "iOS");
-            capabilities.AddAdditionalCapability("deviceName", "iPhone device");
-            capabilities.AddAdditionalCapability("automationName", "XCUITest");
+            capabilities.AddAdditionalCapability("appium:automationName", "XCUITest");
+            capabilities.AddAdditionalCapability("appium:deviceName", "iPhone device");
             //Customizable
-            capabilities.AddAdditionalCapability("bitbar_project", "C# Appium Automated Test");
-            capabilities.AddAdditionalCapability("bitbar_testrun", "iOS Run");
-            capabilities.AddAdditionalCapability("bitbar_device", "Apple iPhone 11");
-            //App ID
-            capabilities.AddAdditionalCapability("bitbar_app", "<APP_ID>");
+            capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+            {
+                {"project", "C# Appium Automated Test"},
+                {"testrun", "iOS Run"},
+                {"device", "Apple iPhone 11"},
+                {"app", "<APP_ID>" }
+                //{"appiumVersion", "1.22.3"} //launch tests on appium 1
+            });
 
             Console.WriteLine("Sending request to start a session. Waiting for response typically takes 2-3 minutes...");
             driver = new IOSDriver<IOSElement>(new Uri(AppiumHubURL), capabilities, TimeSpan.FromSeconds(300));

--- a/samples/testing-frameworks/appium/client-side/csharp/sample-test/Test123/Tests.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/sample-test/Test123/Tests.cs
@@ -20,18 +20,19 @@ namespace TestdroidAndroidSample
 		public void BeforeAll()
 		{
 			ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
-			String BITBAR_APIKEY = "<YOUR BITBAR API KEY>";
+			string BITBAR_APIKEY = "<YOUR BITBAR API KEY>";
+			string BITBAR_APP =  "<ID OF YOUR APP>";
 
 			AppiumOptions capabilities = new AppiumOptions();
 			capabilities.AddAdditionalCapability("platformName", "Android");
 			capabilities.AddAdditionalCapability("appium:automationName", "uiautomator2");
-			capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+			capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, string>
 			{
 				{"project", "C# Appium"},
-				{"testrun", "Android Run 1" },
+				{"testrun", "Android Run 1"},
 				{"device", "Google Pixel 6"}, // See available devices at: https://cloud.bitbar.com/#public/devices
 				{"apiKey", BITBAR_APIKEY},
-				{"app", "<APP ID>"},
+				{"app", BITBAR_APP},
 				//{"appiumVersion", "1.22.3"} //launch tests on appium 1
 			});
 			

--- a/samples/testing-frameworks/appium/client-side/csharp/sample-test/Test123/Tests.cs
+++ b/samples/testing-frameworks/appium/client-side/csharp/sample-test/Test123/Tests.cs
@@ -5,6 +5,7 @@ using OpenQA.Selenium.Appium.Android;
 using System;
 using System.IO;
 using System.Net;
+using System.Collections.Generic;
 
 namespace TestdroidAndroidSample
 {
@@ -22,18 +23,18 @@ namespace TestdroidAndroidSample
 			String BITBAR_APIKEY = "<YOUR BITBAR API KEY>";
 
 			AppiumOptions capabilities = new AppiumOptions();
-			capabilities.AddAdditionalCapability("device", "Android");
-
-			capabilities.AddAdditionalCapability("deviceName", "Android");
 			capabilities.AddAdditionalCapability("platformName", "Android");
-			capabilities.AddAdditionalCapability("bitbar_apiKey", BITBAR_APIKEY);
-			capabilities.AddAdditionalCapability("bitbar_project", "C# Appium");
-			capabilities.AddAdditionalCapability("bitbar_testrun", "Android Run 1");
-
-			// See available devices at: https://cloud.bitbar.com/#public/devices
-			capabilities.AddAdditionalCapability("bitbar_device", "Google Pixel 6");
-			capabilities.AddAdditionalCapability("bitbar_app", "<APP ID>");
-
+			capabilities.AddAdditionalCapability("appium:automationName", "uiautomator2");
+			capabilities.AddAdditionalCapability("bitbar:options", new Dictionary<string, object>
+			{
+				{"project", "C# Appium"},
+				{"testrun", "Android Run 1" },
+				{"device", "Google Pixel 6"}, // See available devices at: https://cloud.bitbar.com/#public/devices
+				{"apiKey", BITBAR_APIKEY},
+				{"app", "<APP ID>"},
+				//{"appiumVersion", "1.22.3"} //launch tests on appium 1
+			});
+			
 			Console.WriteLine("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins");
 			driver = new AndroidDriver<AndroidElement>(new Uri("https://appium.bitbar.com/wd/hub"), capabilities, TimeSpan.FromSeconds(300));
 			Console.WriteLine("WebDriver response received.");


### PR DESCRIPTION
- Added vendor prefixes to capabilities 
- ~~Added `"bitbar_appiumVersion", "2.0"` capability to run appium 2.0 as default~~
- Removed `appium:deviceName` capabilities
- Small refactor of capabilities